### PR TITLE
fix(cli): correct error message in decrypt privateKey validation

### DIFF
--- a/cli/ransomware.go
+++ b/cli/ransomware.go
@@ -209,7 +209,7 @@ func Decrypt(ctx *urfavecli.Context) error {
 	privateKeyPath := ctx.String("privateKey")
 
 	if privateKeyPath == "" {
-		return errors.New("publicKey argument is required")
+		return errors.New("privateKey argument is required")
 	}
 
 	rsaPrivateKey, err := LoadPrivateKey(privateKeyPath)


### PR DESCRIPTION
## Summary

- Fix incorrect error message in `Decrypt` function where the `privateKey` validation error was displaying `"publicKey argument is required"` instead of `"privateKey argument is required"`

Fixes #6

## Changes

In `cli/ransomware.go`, the `Decrypt` function validates that a `privateKey` flag is provided. The error message incorrectly referenced `publicKey`, which would confuse users trying to decrypt files. This was a copy-paste error from the `Encrypt` function's similar validation block.

## Test plan

- [x] Project builds successfully (`go build ./...`)
- [x] `go vet ./...` passes with no issues
- [x] Code formatted with `gofmt -s`