### PR TITLE
fix: correct verbose flag usage description

### DIFF
--- a/main.go
+++ b/main.go
@@ -42,7 +42,7 @@ func main() {
 		Flags: []urfavecli.Flag{
 			&urfavecli.BoolFlag{
 				Name:  "verbose",
-				Usage: "Runs the tool in silent mode (no logs)",
+				Usage: "Runs the tool in verbose mode (more logs)",
 				Value: false,
 			},
 		},


### PR DESCRIPTION
## Summary

- Fixed the `--verbose` flag usage description which incorrectly stated "Runs the tool in silent mode (no logs)" when verbose mode actually enables more logging output
- The description now correctly reads "Runs the tool in verbose mode (more logs)", matching the actual behavior in the `Init()` function

Fixes #7

## Test plan

- [x] Verified `go build ./...` compiles successfully
- [x] Verified `go vet ./...` passes with no new issues
- [x] Verified `gofmt -s` produces no formatting changes
- [x] Confirmed the flag description matches the runtime behavior in `Init()` (lines 18-28 of main.go)