### PR TITLE
fix(fs): prevent panic in IsHidden with bounds checking

### DIFF
--- a/fs/hidden_unix.go
+++ b/fs/hidden_unix.go
@@ -1,5 +1,4 @@
 //go:build !windows
-// +build !windows
 
 package fs
 
@@ -7,8 +6,10 @@ import (
 	"path/filepath"
 )
 
-const dotCharacter = 46
-
 func IsHidden(path string) (bool, error) {
-	return filepath.Base(path)[0] == dotCharacter, nil
+	base := filepath.Base(path)
+	if base == "." || base == ".." {
+		return false, nil
+	}
+	return base[0] == '.', nil
 }

--- a/fs/hidden_windows.go
+++ b/fs/hidden_windows.go
@@ -1,5 +1,4 @@
 //go:build windows
-// +build windows
 
 package fs
 
@@ -8,11 +7,12 @@ import (
 	"syscall"
 )
 
-const dotCharacter = 46
-
 func IsHidden(path string) (bool, error) {
-	// dotfiles also count as hidden (if you want)
-	if path[0] == dotCharacter {
+	base := filepath.Base(path)
+	if base == "." || base == ".." {
+		return false, nil
+	}
+	if base[0] == '.' {
 		return true, nil
 	}
 
@@ -21,10 +21,8 @@ func IsHidden(path string) (bool, error) {
 		return false, err
 	}
 
-	// Appending `\\?\` to the absolute path helps with
-	// preventing 'Path Not Specified Error' when accessing
-	// long paths and filenames
-	// https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation?tabs=cmd
+	// Prefix with `\\?\` to support long paths on Windows.
+	// See: https://docs.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation
 	pointer, err := syscall.UTF16PtrFromString(`\\?\` + absPath)
 	if err != nil {
 		return false, err


### PR DESCRIPTION
## Summary

- Add bounds checking in `IsHidden` to prevent index-out-of-range panics when `filepath.Base()` returns `"."` or `".."`
- Use `filepath.Base()` on Windows instead of indexing the full path string directly, which could panic on edge-case inputs
- Replace magic number constant (`dotCharacter = 46`) with readable `'.'` character literal
- Remove redundant `// +build` directives (superseded by `//go:build` since Go 1.17)

Fixes #9

## Changes

**`fs/hidden_unix.go`**
- Extract `filepath.Base(path)` into a local variable
- Guard against `"."` and `".."` before indexing
- Replace `dotCharacter` constant with `'.'` literal

**`fs/hidden_windows.go`**
- Use `filepath.Base(path)` instead of indexing `path` directly
- Guard against `"."` and `".."` before indexing
- Replace `dotCharacter` constant with `'.'` literal
- Simplify long-path comment

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt -s` reports no formatting issues
- [ ] Manual verification: call `IsHidden(".")`, `IsHidden("..")`, `IsHidden("")` -- all should return `(false, nil)` without panicking