### PR TITLE
fix(cli): use dynamic RSA key size instead of hardcoded 256

### DIFF
--- a/cli/ransomware.go
+++ b/cli/ransomware.go
@@ -297,10 +297,10 @@ func decryptFile(path string, rsaPrivateKey *rsa.PrivateKey, encSuffix string) e
 		return err
 	}
 
-	byteReader := bytes.NewReader(cipherText)
-	encryptedAesKey := make([]byte, 256)
+	keySize := rsaPrivateKey.Size()
+	encryptedAesKey := make([]byte, keySize)
 
-	_, err = byteReader.ReadAt(encryptedAesKey, 0)
+	_, err = bytes.NewReader(cipherText).ReadAt(encryptedAesKey, 0)
 
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Replace hardcoded 256-byte RSA key size in `decryptFile` with `rsaPrivateKey.Size()`, ensuring correctness if `RSA_KEY_SIZE` is ever changed
- Inline the `byteReader` variable for cleaner code

Fixes #10

## Changes

In `cli/ransomware.go`, the `decryptFile` function previously allocated a fixed 256-byte buffer for the encrypted AES key. This assumed a 2048-bit RSA key. The fix uses `rsaPrivateKey.Size()` to dynamically determine the correct buffer size based on the actual key.

## Test plan

- [x] Project builds cleanly (`go build ./...`)
- [x] `go vet ./...` passes
- [x] `gofmt -s` formatting verified
- [x] No new lint issues introduced (pre-existing errcheck warnings are unchanged)