### PR TITLE
fix(cli): check writer.Flush and DeleteFileIfExists errors

### DIFF
--- a/cli/ransomware.go
+++ b/cli/ransomware.go
@@ -190,7 +190,9 @@ func Encrypt(ctx *urfavecli.Context) error {
 				return err
 			}
 
-			writer.Flush()
+			if err := writer.Flush(); err != nil {
+				return err
+			}
 		} else {
 			log.Printf("Ransom file already exists at %s. Skipping generation", ransomPath)
 		}
@@ -258,10 +260,12 @@ func Decrypt(ctx *urfavecli.Context) error {
 		return nil
 	})
 
-	// Delete root ransom file (if any)
-	fs.DeleteFileIfExists(filepath.Join(absolutePath, ransomFileName))
+	if err != nil {
+		return err
+	}
 
-	return err
+	// Delete root ransom file (if any)
+	return fs.DeleteFileIfExists(filepath.Join(absolutePath, ransomFileName))
 }
 
 func encryptFile(path string, aesKey crypto.AesKey, encryptedAesKey []byte, encSuffix string) error {


### PR DESCRIPTION
## Summary

- Check `writer.Flush()` return value when writing the ransom template file, propagating errors instead of silently ignoring them
- Properly check the `WalkFilesWithExtFilter` error in `Decrypt` before proceeding to delete the ransom file
- Return `DeleteFileIfExists` error directly instead of discarding it during decrypt cleanup

Fixes #12

## Test plan

- [x] Verify `go build ./...` succeeds
- [x] Verify `go vet ./...` passes
- [x] Verify `gofmt -s -l .` produces no output
- [x] Review that error propagation is correct in both `Encrypt` and `Decrypt` functions