### PR TITLE
docs: fix RSA key size in README ransom template example

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ This is an example of ransom file. The templated strings `{{.BitcoinAddress}}`, 
 ```txt
 !!! IMPORTANT !!!
 
-All of your files are encrypted with RSA 4096 and AES 256 ciphers.
+All of your files are encrypted with RSA 2048 and AES 256 ciphers.
 More information about RSA and AES can be found here:
 - https://en.wikipedia.org/wiki/RSA_(cryptosystem)
 - https://en.wikipedia.org/wiki/Advanced_Encryption_Standard


### PR DESCRIPTION
## Summary

- Fix incorrect RSA key size in the README ransom template example: changed "RSA 4096" to "RSA 2048" to match the actual key size defined in `crypto/rsa.go` (`RSA_KEY_SIZE = 2048`)

The actual ransom template file (`ransom/IMPORTANT.txt`) already correctly states RSA 2048. Only the README example was out of sync.

Fixes #13