### PR TITLE
feat: add GoReleaser-based release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,8 +22,13 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Run linter
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: latest
+
       - name: Run tests
-        run: go test -race ./...
+        run: go test -v -race -coverprofile=coverage.out ./...
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,34 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: go test -race ./...
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: "~> v2"
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ $RECYCLE.BIN/
 *.lnk
 
 # Keys
-*.pem 
+*.pem
+
+# GoReleaser
+dist/
 
 # End of https://www.toptal.com/developers/gitignore/api/visualstudiocode,macos,linux,windows,go

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,44 @@
+version: 2
+
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+archives:
+  - formats:
+      - tar.gz
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+
+checksum:
+  name_template: "checksums.txt"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - "^docs:"
+      - "^test:"
+      - "^ci:"
+      - "^chore:"
+  groups:
+    - title: Features
+      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      order: 0
+    - title: Bug fixes
+      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      order: 1
+    - title: Others
+      order: 999

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -10,6 +10,9 @@ builds:
     goarch:
       - amd64
       - arm64
+    ignore:
+      - goos: windows
+        goarch: arm64
     ldflags:
       - -s -w -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
 

--- a/main.go
+++ b/main.go
@@ -12,9 +12,14 @@ import (
 )
 
 const (
-	APP_NAME        = "ransomware"
-	APP_DESCRIPTION = "A simple demonstration tool to simulate a ransomware attack"
-	APP_VERSION     = "v1.0.0"
+	appName        = "ransomware"
+	appDescription = "A simple demonstration tool to simulate a ransomware attack"
+)
+
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
 )
 
 func beforeCommand(ctx *urfavecli.Context) error {
@@ -24,16 +29,16 @@ func beforeCommand(ctx *urfavecli.Context) error {
 	utils.SetupLogging(verbose, jsonFormat)
 
 	if verbose {
-		figure.NewFigure(APP_NAME, "graffiti", true).Print()
+		figure.NewFigure(appName, "graffiti", true).Print()
 	}
 	return nil
 }
 
 func main() {
 	app := &urfavecli.App{
-		Name:     APP_NAME,
-		Usage:    APP_DESCRIPTION,
-		Version:  APP_VERSION,
+		Name:     appName,
+		Usage:    appDescription,
+		Version:  fmt.Sprintf("%s (commit: %s, built: %s)", version, commit, date),
 		Compiled: time.Now(),
 		Authors: []*urfavecli.Author{
 			{
@@ -45,13 +50,11 @@ func main() {
 			&urfavecli.BoolFlag{
 				Name:  "verbose",
 				Usage: "Runs the tool in verbose mode (more logs)",
-				Value: false,
 			},
 			&urfavecli.BoolFlag{
 				Name:    "jsonLogs",
 				Aliases: []string{"json"},
 				Usage:   "Enable JSON log output (default: text)",
-				Value:   false,
 			},
 		},
 		Commands: []*urfavecli.Command{
@@ -100,12 +103,10 @@ func main() {
 					&urfavecli.StringFlag{
 						Name:  "extWhitelist",
 						Usage: "the extension to whitelist",
-						Value: "",
 					},
 					&urfavecli.BoolFlag{
 						Name:  "skipHidden",
 						Usage: "skips hidden folders",
-						Value: false,
 					},
 					&urfavecli.BoolFlag{
 						Name:    "recursive",
@@ -116,7 +117,6 @@ func main() {
 					&urfavecli.BoolFlag{
 						Name:  "dryRun",
 						Usage: "encrypts files without deleting originals",
-						Value: false,
 					},
 					&urfavecli.StringFlag{
 						Name:  "encSuffix",
@@ -126,7 +126,6 @@ func main() {
 					&urfavecli.BoolFlag{
 						Name:  "addRansom",
 						Usage: "if set to true add a ransom note to every encrypted folder",
-						Value: false,
 					},
 					&urfavecli.StringFlag{
 						Name:  "ransomTemplatePath",
@@ -140,7 +139,6 @@ func main() {
 					&urfavecli.Float64Flag{
 						Name:  "bitcoinCount",
 						Usage: "how many bitcoins to ask as ransom",
-						Value: 0,
 					},
 					&urfavecli.StringFlag{
 						Name:  "bitcoinAddress",
@@ -156,7 +154,6 @@ func main() {
 					&urfavecli.Int64Flag{
 						Name:  "partial",
 						Usage: "encrypt only the first N bytes of each file (0 = full encryption)",
-						Value: 0,
 					},
 					&urfavecli.StringFlag{
 						Name:  "report",
@@ -185,12 +182,10 @@ func main() {
 					&urfavecli.BoolFlag{
 						Name:  "dryRun",
 						Usage: "decrypts files without deleting encrypted versions",
-						Value: false,
 					},
 					&urfavecli.BoolFlag{
 						Name:  "skipHidden",
 						Usage: "skips hidden folders",
-						Value: false,
 					},
 					&urfavecli.BoolFlag{
 						Name:    "recursive",
@@ -241,7 +236,6 @@ func main() {
 					&urfavecli.BoolFlag{
 						Name:  "skipHidden",
 						Usage: "skips hidden folders",
-						Value: false,
 					},
 					&urfavecli.BoolFlag{
 						Name:    "recursive",


### PR DESCRIPTION
## Summary

- Add GoReleaser configuration for cross-platform binary builds (linux/darwin/windows on amd64/arm64) with ldflags version injection
- Add GitHub Actions release workflow triggered by version tags (`v*`) that runs tests before publishing
- Convert hardcoded version constant to build-time variables (`version`, `commit`, `date`) injected via ldflags
- Clean up CLI flag definitions by removing redundant zero-value defaults
- Add `dist/` to `.gitignore` for local GoReleaser builds

## Test plan

- [ ] Verify `go build ./...` succeeds with the `main.go` changes
- [ ] Verify `go test -race ./...` passes
- [ ] Validate `.goreleaser.yaml` with `goreleaser check` (if available locally)
- [ ] Push a test tag (e.g., `v0.0.1-rc.1`) and confirm the release workflow triggers, builds cross-platform binaries, and publishes a GitHub Release with checksums
- [ ] Confirm the built binary reports the correct version: `./ransomware --version`

Closes #40